### PR TITLE
Add format_json.py: PEP 8-compliant JSON beautifier

### DIFF
--- a/format_json.py
+++ b/format_json.py
@@ -16,18 +16,44 @@ Options:
 
 import argparse
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
+
+
+def unescape_strings(obj):
+    """Recursively expand \\n and \\t in string values before serialization."""
+    if isinstance(obj, str):
+        return obj.replace("\\n", "\n").replace("\\t", "\t")
+    if isinstance(obj, dict):
+        return {
+            unescape_strings(k): unescape_strings(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [unescape_strings(item) for item in obj]
+    return obj
 
 
 def process(text, output_path=None, indent=2):
     """Parse, beautify, and unescape a JSON string."""
     data = json.loads(text, strict=False)
-    formatted = json.dumps(data, indent=indent, ensure_ascii=False)
-    formatted = formatted.replace("\\n", "\n").replace("\\t", "\t")
+    data = unescape_strings(data)
+    formatted = json.dumps(
+        data, indent=indent, ensure_ascii=False, allow_nan=False
+    )
 
     if output_path:
-        Path(output_path).write_text(formatted + "\n", encoding="utf-8")
+        dest = Path(output_path)
+        fd, tmp = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(formatted + "\n")
+            os.replace(tmp, dest)
+        except Exception:
+            os.unlink(tmp)
+            raise
         print(f"Written to {output_path}")
     else:
         print(formatted)
@@ -59,6 +85,13 @@ def main():
         help="Overwrite input file(s)",
     )
     args = parser.parse_args()
+
+    if args.in_place and args.output:
+        print(
+            "Error: --in-place and --output are mutually exclusive.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if args.output and len(args.files) > 1:
         print(

--- a/format_json.py
+++ b/format_json.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Beautify JSON and expand escape sequences in string values.
+
+Usage:
+    1. Pipe a blob:             echo '{"key":"val"}' | python3 format_json.py
+    2. Paste interactively      python3 format_json.py
+       (end input with Ctrl+D):
+    3. File(s):                 python3 format_json.py input.json
+
+Options:
+    -o, --output FILE    Write output to FILE (single input only)
+    -i, --indent N       Indentation spaces (default: 2)
+    --in-place           Overwrite input file(s)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def process(text, output_path=None, indent=2):
+    """Parse, beautify, and unescape a JSON string."""
+    data = json.loads(text, strict=False)
+    formatted = json.dumps(data, indent=indent, ensure_ascii=False)
+    formatted = formatted.replace("\\n", "\n").replace("\\t", "\t")
+
+    if output_path:
+        Path(output_path).write_text(formatted + "\n", encoding="utf-8")
+        print(f"Written to {output_path}")
+    else:
+        print(formatted)
+
+
+def main():
+    """Entry point for the format_json CLI."""
+    parser = argparse.ArgumentParser(
+        description="Beautify JSON and expand \\n and \\t sequences."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Input JSON file(s); omit to read from stdin",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        help="Output file (only valid for a single input file)",
+    )
+    parser.add_argument(
+        "-i", "--indent",
+        type=int,
+        default=2,
+        help="Indentation spaces (default: 2)",
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Overwrite input file(s)",
+    )
+    args = parser.parse_args()
+
+    if args.output and len(args.files) > 1:
+        print(
+            "Error: --output can only be used with a single input file.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not args.files:
+        if sys.stdin.isatty():
+            print(
+                "Reading JSON (paste below, then press Ctrl+D):",
+                file=sys.stderr,
+            )
+        text = sys.stdin.read()
+        process(text, output_path=args.output, indent=args.indent)
+        return
+
+    for path in args.files:
+        text = Path(path).read_text(encoding="utf-8")
+        out = path if args.in_place else args.output
+        process(text, output_path=out, indent=args.indent)
+
+
+if __name__ == "__main__":
+    main()

--- a/format_json.py
+++ b/format_json.py
@@ -17,6 +17,7 @@ Options:
 import argparse
 import json
 import os
+import stat
 import sys
 import tempfile
 from pathlib import Path
@@ -27,10 +28,7 @@ def unescape_strings(obj):
     if isinstance(obj, str):
         return obj.replace("\\n", "\n").replace("\\t", "\t")
     if isinstance(obj, dict):
-        return {
-            unescape_strings(k): unescape_strings(v)
-            for k, v in obj.items()
-        }
+        return {k: unescape_strings(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [unescape_strings(item) for item in obj]
     return obj
@@ -50,6 +48,8 @@ def process(text, output_path=None, indent=2):
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(formatted + "\n")
+            if dest.exists():
+                os.chmod(tmp, stat.S_IMODE(dest.stat().st_mode))
             os.replace(tmp, dest)
         except Exception:
             os.unlink(tmp)
@@ -101,6 +101,12 @@ def main():
         sys.exit(1)
 
     if not args.files:
+        if args.in_place:
+            print(
+                "Error: --in-place requires at least one input file.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if sys.stdin.isatty():
             print(
                 "Reading JSON (paste below, then press Ctrl+D):",


### PR DESCRIPTION
## Summary

- Adds `format_json.py`, a CLI script to format/beautify unformatted JSON
- Expands `\n` and `\t` escape sequences in string values to actual newlines and tabs (handy for stack traces in log JSON)
- Written to comply with PEP 8: docstrings on all public functions, 4-space indentation, 79-char line limit, snake_case naming, sorted imports

## Usage

| Method | Command |
|--------|---------|
| Pipe a blob | `echo '{"key":"val"}' \| python3 format_json.py` |
| Interactive paste | `python3 format_json.py` (end with Ctrl+D) |
| File(s) | `python3 format_json.py input.json` |

## Options

| Flag | Description |
|------|-------------|
| `-o, --output FILE` | Write output to a file |
| `-i, --indent N` | Indentation width (default: 2) |
| `--in-place` | Overwrite input file(s) |

## Test plan

- [ ] `echo '{"a":"line1\nline2"}' | python3 format_json.py` — newlines expand in output
- [ ] `python3 format_json.py input.json` — file input formats correctly
- [ ] `python3 format_json.py --in-place input.json` — overwrites file in place
- [ ] `python3 format_json.py input.json -o out.json` — writes to separate file
- [ ] JSON with embedded stack traces (control characters) parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to pretty-print JSON from files or standard input.
  * Supports configurable indentation.
  * Expands escaped newline (`\n`) and tab (`\t`) sequences within string values, including nested structures.
  * Outputs to stdout, a chosen file, or can overwrite input files in place with validation to prevent conflicting options and safer write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->